### PR TITLE
docs: add GitLab CI integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -135,3 +135,5 @@ poetry.lock
 docs/_build/
 # sphinxnotes-any >= 2.5
 docs/.any*
+
+.worktrees/

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,18 @@
+image: python:3.12
+
+stages:
+  - docs
+
+cache:
+  key: sphinxnotes-incrbuild
+  paths:
+    - /tmp/sphinxnotes-incrbuild
+
+pages:
+  stage: docs
+  script:
+    - pip install sphinxnotes-incrbuild
+    - sphinxnotes-incrbuild docs public
+  artifacts:
+    paths:
+      - public

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -105,7 +105,29 @@ __ https://github.com/marketplace/actions/sphinx-to-github-pages
 GitLab CI
 ---------
 
-TODO
+``sphinxnotes-incrbuild`` can be used in GitLab CI with the cache mechanism:
+
+.. code-block:: yaml
+   :emphasize-lines: 4-5,10
+
+   image: python:3.12
+
+   stages:
+     - docs
+
+   cache:
+     key: sphinxnotes-incrbuild
+     paths:
+       - /tmp/sphinxnotes-incrbuild
+
+   pages:
+     stage: docs
+     script:
+       - pip install sphinxnotes-incrbuild
+       - sphinxnotes-incrbuild docs public
+     artifacts:
+       paths:
+         - public
 
 Contents
 ========


### PR DESCRIPTION
## Summary
- Add `.gitlab-ci.yml` for GitLab CI integration with sphinxnotes-incrbuild cache support
- Update `docs/index.rst` with GitLab CI configuration example